### PR TITLE
improve impedance readout

### DIFF
--- a/curryreader.py
+++ b/curryreader.py
@@ -195,11 +195,11 @@ def read(inputfilename='', plotdata = 1, verbosity = 2):
     if tixstart != -1 and tixstop != 1 :
         text = contents[tixstart:tixstop - 1].split()
         for imp in text:
-           if int(imp) != -1:                   # skip?
-               impedancelist.append(float(imp))
+            impedancelist.append(float(imp) if imp!="-1" else np.nan)
     
         # Curry records last 10 impedances
         impedancematrix = np.asarray(impedancelist, dtype = float).reshape(int(len(impedancelist) / nChannels), nChannels)
+        impedancematrix = impedancematrix[~np.isnan(impedancematrix).all(axis=1)]
     
     if impedancematrix.any():
         log.info('Found impedance matrix')


### PR DESCRIPTION
hi devs!

a small PR that I believe fixes the issue I reported in #8.

basically, `-1` impedance values are now imported as `nan`, which prevents the matrix reshape error during readout.
empty rows are dropped afterwards

locally, `pytest` results are not impaired

closes #8 